### PR TITLE
Relax node engine requirements

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,8 +40,8 @@
         "nodemon": "3.0.1"
       },
       "engines": {
-        "node": "20.9.0",
-        "npm": "10.2.4"
+        "node": ">=20.9.0",
+        "npm": ">=10.2.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,8 +2,8 @@
   "name": "idurar-erp-crm",
   "version": "4.1.0",
   "engines": {
-    "npm": "10.2.4",
-    "node": "20.9.0"
+    "npm": ">=10.2.4",
+    "node": ">=20.9.0"
   },
   "scripts": {
     "start": "node src/server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,8 +38,8 @@
         "prettier": "3.1.0"
       },
       "engines": {
-        "node": "20.9.0",
-        "npm": "10.2.4"
+        "node": ">=20.9.0",
+        "npm": ">=10.2.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,8 +2,8 @@
   "name": "idurar-erp-crm",
   "version": "4.1.0",
   "engines": {
-    "node": "20.9.0",
-    "npm": "10.2.4"
+    "node": ">=20.9.0",
+    "npm": ">=10.2.4"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary
- allow newer Node and npm versions by relaxing engine settings in package.json files

## Testing
- `node --version`
- `npm --version`

`npm install` could not run because the environment does not have internet access.

------
https://chatgpt.com/codex/tasks/task_e_685c0d6d5ba083208dbf3068042f5c5a