### PR TITLE
Update env setup docs

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,7 +1,8 @@
-#DATABASE = "mongodb://localhost:27017"
-#RESEND_API = "your resend_api"
-#OPENAI_API_KEY = "your open_ai api key"
-JWT_SECRET= "your_private_jwt_secret_key"
-NODE_ENV = "production"
+DATABASE="mongodb://localhost:27017/idurar"
+#RESEND_API="your_resend_api"
+#OPENAI_API_KEY="your_openai_api_key"
+JWT_SECRET="your_private_jwt_secret_key"
+NODE_ENV="production"
 OPENSSL_CONF='/dev/null'
 PUBLIC_SERVER_FILE="http://localhost:8888/"
+

--- a/doc/README.sp.md
+++ b/doc/README.sp.md
@@ -96,6 +96,27 @@ IDURAR es un ERP/CRM de Código Abierto y "Fair-Code" (Facturación/Inventario/C
 
 3.[Edita el archivo de entorno](INSTALLATION-INSTRUCTIONS.md#Step-3-Edit-the-Environment-File)
 
+### Configuración de entorno
+
+En `/backend` encontrarás un archivo llamado `.env`. Completa las variables de ejemplo para conectar tu base de datos y definir claves privadas:
+
+```bash
+DATABASE="mongodb://localhost:27017/idurar"
+JWT_SECRET="tu_clave_privada"
+NODE_ENV="production"
+OPENSSL_CONF='/dev/null'
+PUBLIC_SERVER_FILE="http://localhost:8888/"
+#RESEND_API="tu_token_resend"       # opcional para envíos de correo
+#OPENAI_API_KEY="tu_api_key_openai" # opcional para funciones de IA
+```
+
+Para que el frontend pueda comunicarse con el backend, edita el fichero `.env` dentro de `/frontend` y establece:
+
+```bash
+VITE_FILE_BASE_URL='http://localhost:8888/'
+VITE_BACKEND_SERVER='http://localhost:8888/'
+```
+
 4.[Actualiza la URI de MongoDB](INSTALLATION-INSTRUCTIONS.md#Step-4-Update-MongoDB-URI)
 
 5.[Instala las Dependencias del Backend](INSTALLATION-INSTRUCTIONS.md#Step-5-Install-Backend-Dependencies)

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,5 +1,3 @@
 
-# ----> Remove # comment
-VITE_FILE_BASE_URL = 'http://localhost:8888/'
-VITE_BACKEND_SERVER="http://your_backend_url_server.com/"
-PROD = false
+VITE_FILE_BASE_URL='http://localhost:8888/'
+VITE_BACKEND_SERVER='http://localhost:8888/'


### PR DESCRIPTION
## Summary
- document backend and frontend env configuration in Spanish docs
- provide example configuration in backend/.env and frontend/.env

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c272134e88320ba3d55928e95c907