### PR TITLE
Add combined dev script and update docs

### DIFF
--- a/INSTALLATION-INSTRUCTIONS.md
+++ b/INSTALLATION-INSTRUCTIONS.md
@@ -146,4 +146,20 @@ After trying above solutions, run below command
 npm run dev
 ```
 
+#### Step 10: Start Both Servers from the Project Root
+
+If you prefer running the backend and frontend together, you can use the helper `package.json` located at the repository root. First install all dependencies:
+
+```bash
+npm install
+```
+
+Then start both servers concurrently:
+
+```bash
+npm run dev
+```
+
+This will run the backend on port `8888` and the frontend on port `3000`.
+
 > If you still facing issue, then follow [this stackoverflow thread](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported). It has so many different types of opinions. You definitely have solution after going through the thread.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ IDURAR is Open "Fair-Code" Source ERP / CRM (Invoice / Inventory / Accounting / 
 8.[Install Frontend Dependencies](INSTALLATION-INSTRUCTIONS.md#Step-8-Install-Frontend-Dependencies)
 
 9.[Run the Frontend Server](INSTALLATION-INSTRUCTIONS.md#Step-9-Run-the-Frontend-Server)
+10.[Start Both Servers from the Project Root](INSTALLATION-INSTRUCTIONS.md#Step-10-Start-Both-Servers-from-the-Project-Root)
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "idura-root",
+  "private": true,
+  "scripts": {
+    "dev": "npm-run-all --parallel dev:*",
+    "dev:backend": "npm --prefix backend run dev",
+    "dev:frontend": "npm --prefix frontend run dev"
+  },
+  "devDependencies": {
+    "npm-run-all": "^4.1.5"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `package.json` in repo root with helper dev scripts
- document new step to start both backend and frontend from the root
- link the new step from the README

## Testing
- `npm run lint` (fails: ESLint couldn't find config)
- `npm run --silent test` (no test script)


------
https://chatgpt.com/codex/tasks/task_e_685c7e20a28883208a693495381118b3