### PR TITLE
Fix dev script for older Node

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,11 +28,11 @@
     "vite": "^5.4.8"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "dev:remote": "cross-env VITE_DEV_REMOTE=remote npm run dev"
+    "dev:remote": "cross-env VITE_DEV_REMOTE=remote NODE_OPTIONS=--openssl-legacy-provider vite"
   },
   "devDependencies": {
     "@types/react": "^18.2.38",


### PR DESCRIPTION
## Summary
- use cross-env to set `NODE_OPTIONS` with legacy provider in dev scripts

## Testing
- `npm run dev` *(fails: npm-run-all missing because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c93c421fc832097809dd667fa3aaa