### PR TITLE
Add Ansimaq modules

### DIFF
--- a/backend/src/controllers/appControllers/equipmentController/index.js
+++ b/backend/src/controllers/appControllers/equipmentController/index.js
@@ -1,0 +1,5 @@
+const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+
+const methods = createCRUDController('Equipment');
+
+module.exports = methods;

--- a/backend/src/controllers/appControllers/equipmentRentalController/create.js
+++ b/backend/src/controllers/appControllers/equipmentRentalController/create.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const Equipment = mongoose.model('Equipment');
+const EquipmentRental = mongoose.model('EquipmentRental');
+
+const create = async (req, res) => {
+  const { equipment, quantity = 0 } = req.body;
+
+  const item = await Equipment.findById(equipment);
+  if (!item) {
+    return res.status(404).json({ success: false, message: 'Equipment not found', result: null });
+  }
+
+  let status = 'rented';
+  if (item.quantity < quantity) {
+    status = 'external';
+  } else {
+    item.quantity -= quantity;
+    await item.save();
+  }
+
+  const result = await EquipmentRental.create({
+    ...req.body,
+    status,
+    createdBy: req.admin._id,
+  });
+
+  return res.status(200).json({ success: true, result, message: 'Rental created' });
+};
+
+module.exports = create;

--- a/backend/src/controllers/appControllers/equipmentRentalController/index.js
+++ b/backend/src/controllers/appControllers/equipmentRentalController/index.js
@@ -1,0 +1,7 @@
+const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
+const create = require('./create');
+
+const methods = createCRUDController('EquipmentRental');
+methods.create = create;
+
+module.exports = methods;

--- a/backend/src/locale/translation/en_us.js
+++ b/backend/src/locale/translation/en_us.js
@@ -449,4 +449,12 @@ module.exports = {
   enter_code: 'Enter Code',
   offers: 'Offers',
   proforma_invoices: 'quote',
+  equipment: 'Equipment',
+  equipment_list: 'Equipment List',
+  add_new_equipment: 'Add New Equipment',
+  equipment_rental: 'Equipment Rental',
+  equipment_rental_list: 'Equipment Rental List',
+  add_new_equipment_rental: 'Add New Equipment Rental',
+  billing: 'Billing',
+  connect_to_tax_service: 'Connect to Impuestos Internos',
 };

--- a/backend/src/models/appModels/Equipment.js
+++ b/backend/src/models/appModels/Equipment.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const equipmentSchema = new mongoose.Schema({
+  removed: {
+    type: Boolean,
+    default: false,
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  quantity: {
+    type: Number,
+    default: 0,
+  },
+  rentalProvider: String,
+  created: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+equipmentSchema.plugin(require('mongoose-autopopulate'));
+module.exports = mongoose.model('Equipment', equipmentSchema);

--- a/backend/src/models/appModels/EquipmentRental.js
+++ b/backend/src/models/appModels/EquipmentRental.js
@@ -1,0 +1,37 @@
+const mongoose = require('mongoose');
+
+const rentalSchema = new mongoose.Schema({
+  removed: {
+    type: Boolean,
+    default: false,
+  },
+  equipment: {
+    type: mongoose.Schema.ObjectId,
+    ref: 'Equipment',
+    required: true,
+    autopopulate: true,
+  },
+  quantity: {
+    type: Number,
+    required: true,
+  },
+  provider: String,
+  status: {
+    type: String,
+    default: 'rented',
+    enum: ['rented', 'external', 'returned'],
+  },
+  rentalDate: {
+    type: Date,
+    default: Date.now,
+  },
+  returnDate: Date,
+  createdBy: { type: mongoose.Schema.ObjectId, ref: 'Admin' },
+  created: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+rentalSchema.plugin(require('mongoose-autopopulate'));
+module.exports = mongoose.model('EquipmentRental', rentalSchema);

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -75,6 +75,21 @@ function Sidebar({ collapsible, isMobile = false }) {
       icon: <CreditCardOutlined />,
       label: <Link to={'/payment'}>{translate('payments')}</Link>,
     },
+    {
+      key: 'equipment',
+      icon: <TagOutlined />,
+      label: <Link to={'/equipment'}>{translate('equipment')}</Link>,
+    },
+    {
+      key: 'rental',
+      icon: <TagsOutlined />,
+      label: <Link to={'/rental'}>{translate('equipment_rental')}</Link>,
+    },
+    {
+      key: 'billing',
+      icon: <FileOutlined />,
+      label: <Link to={'/billing'}>{translate('billing')}</Link>,
+    },
 
     {
       key: 'paymentMode',

--- a/frontend/src/locale/translation/en_us.js
+++ b/frontend/src/locale/translation/en_us.js
@@ -449,6 +449,14 @@ const lang = {
   enter_code: 'Enter Code',
   offers: 'Offers',
   proforma_invoices: 'quote',
+  equipment: 'Equipment',
+  equipment_list: 'Equipment List',
+  add_new_equipment: 'Add New Equipment',
+  equipment_rental: 'Equipment Rental',
+  equipment_rental_list: 'Equipment Rental List',
+  add_new_equipment_rental: 'Add New Equipment Rental',
+  billing: 'Billing',
+  connect_to_tax_service: 'Connect to Impuestos Internos',
   search: 'search',
 };
 

--- a/frontend/src/modules/AuthModule/SideContent.jsx
+++ b/frontend/src/modules/AuthModule/SideContent.jsx
@@ -1,5 +1,5 @@
 import { Space, Layout, Divider, Typography } from 'antd';
-import logo from '@/style/images/idurar-crm-erp.svg';
+import logo from '@/style/images/ansimaq-logo.svg';
 import useLanguage from '@/locale/useLanguage';
 import { useSelector } from 'react-redux';
 

--- a/frontend/src/modules/AuthModule/index.jsx
+++ b/frontend/src/modules/AuthModule/index.jsx
@@ -5,7 +5,7 @@ import { Layout, Col, Divider, Typography } from 'antd';
 import AuthLayout from '@/layout/AuthLayout';
 import SideContent from './SideContent';
 
-import logo from '@/style/images/idurar-crm-erp.svg';
+import logo from '@/style/images/ansimaq-logo.svg';
 
 const { Content } = Layout;
 const { Title } = Typography;

--- a/frontend/src/pages/Billing/index.jsx
+++ b/frontend/src/pages/Billing/index.jsx
@@ -1,0 +1,16 @@
+import { Typography } from 'antd';
+import useLanguage from '@/locale/useLanguage';
+
+export default function Billing() {
+  const translate = useLanguage();
+  const { Title, Paragraph } = Typography;
+
+  return (
+    <div style={{ padding: 24 }}>
+      <Title level={2}>{translate('billing')}</Title>
+      <Paragraph>
+        {translate('connect_to_tax_service')}
+      </Paragraph>
+    </div>
+  );
+}

--- a/frontend/src/pages/Equipment/config.js
+++ b/frontend/src/pages/Equipment/config.js
@@ -1,0 +1,5 @@
+export const fields = {
+  name: { type: 'string', required: true },
+  quantity: { type: 'number', required: true },
+  rentalProvider: { type: 'string' },
+};

--- a/frontend/src/pages/Equipment/index.jsx
+++ b/frontend/src/pages/Equipment/index.jsx
@@ -1,0 +1,40 @@
+import CrudModule from '@/modules/CrudModule/CrudModule';
+import DynamicForm from '@/forms/DynamicForm';
+import useLanguage from '@/locale/useLanguage';
+import { fields } from './config';
+
+export default function Equipment() {
+  const translate = useLanguage();
+  const entity = 'equipment';
+  const searchConfig = {
+    displayLabels: ['name'],
+    searchFields: 'name',
+  };
+  const deleteModalLabels = ['name'];
+
+  const Labels = {
+    PANEL_TITLE: translate('equipment'),
+    DATATABLE_TITLE: translate('equipment_list'),
+    ADD_NEW_ENTITY: translate('add_new_equipment'),
+    ENTITY_NAME: translate('equipment'),
+  };
+
+  const configPage = {
+    entity,
+    ...Labels,
+  };
+  const config = {
+    ...configPage,
+    fields,
+    searchConfig,
+    deleteModalLabels,
+  };
+
+  return (
+    <CrudModule
+      createForm={<DynamicForm fields={fields} />}
+      updateForm={<DynamicForm fields={fields} isUpdateForm={true} />}
+      config={config}
+    />
+  );
+}

--- a/frontend/src/pages/Rental/config.js
+++ b/frontend/src/pages/Rental/config.js
@@ -1,0 +1,13 @@
+export const fields = {
+  equipment: {
+    type: 'select',
+    entity: 'equipment',
+    displayLabels: ['name'],
+    searchFields: 'name',
+    outputValue: '_id',
+  },
+  quantity: { type: 'number', required: true },
+  provider: { type: 'string' },
+  status: { type: 'string', disableForUpdate: false },
+  returnDate: { type: 'date' },
+};

--- a/frontend/src/pages/Rental/index.jsx
+++ b/frontend/src/pages/Rental/index.jsx
@@ -1,0 +1,40 @@
+import CrudModule from '@/modules/CrudModule/CrudModule';
+import DynamicForm from '@/forms/DynamicForm';
+import useLanguage from '@/locale/useLanguage';
+import { fields } from './config';
+
+export default function Rental() {
+  const translate = useLanguage();
+  const entity = 'equipmentrental';
+  const searchConfig = {
+    displayLabels: ['equipment.name'],
+    searchFields: 'equipment.name',
+  };
+  const deleteModalLabels = ['equipment.name'];
+
+  const Labels = {
+    PANEL_TITLE: translate('equipment_rental'),
+    DATATABLE_TITLE: translate('equipment_rental_list'),
+    ADD_NEW_ENTITY: translate('add_new_equipment_rental'),
+    ENTITY_NAME: translate('equipment_rental'),
+  };
+
+  const configPage = {
+    entity,
+    ...Labels,
+  };
+  const config = {
+    ...configPage,
+    fields,
+    searchConfig,
+    deleteModalLabels,
+  };
+
+  return (
+    <CrudModule
+      createForm={<DynamicForm fields={fields} />}
+      updateForm={<DynamicForm fields={fields} isUpdateForm={true} />}
+      config={config}
+    />
+  );
+}

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -20,6 +20,9 @@ const QuoteUpdate = lazy(() => import('@/pages/Quote/QuoteUpdate'));
 const Payment = lazy(() => import('@/pages/Payment/index'));
 const PaymentRead = lazy(() => import('@/pages/Payment/PaymentRead'));
 const PaymentUpdate = lazy(() => import('@/pages/Payment/PaymentUpdate'));
+const Equipment = lazy(() => import('@/pages/Equipment'));
+const Rental = lazy(() => import('@/pages/Rental'));
+const Billing = lazy(() => import('@/pages/Billing'));
 
 const Settings = lazy(() => import('@/pages/Settings/Settings'));
 const PaymentMode = lazy(() => import('@/pages/PaymentMode'));
@@ -100,6 +103,18 @@ let routes = {
     {
       path: '/payment/update/:id',
       element: <PaymentUpdate />,
+    },
+    {
+      path: '/equipment',
+      element: <Equipment />,
+    },
+    {
+      path: '/rental',
+      element: <Rental />,
+    },
+    {
+      path: '/billing',
+      element: <Billing />,
     },
 
     {

--- a/frontend/src/style/images/ansimaq-logo.svg
+++ b/frontend/src/style/images/ansimaq-logo.svg
@@ -1,0 +1,4 @@
+<svg width="200" height="50" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="50" fill="#284E8E" />
+  <text x="100" y="35" font-size="24" fill="white" text-anchor="middle" font-family="Arial">ANSIMAQ</text>
+</svg>


### PR DESCRIPTION
## Summary
- update login logo to ansimaq branding
- add translations and navigation for equipment and billing
- implement equipment and rental models/controllers
- include basic CRUD pages for equipment, rentals, and billing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cd51d8b8483209ddd534cd659dd20